### PR TITLE
Add support for Lit 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weavedev/lit-i18next",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0-rc.1",
   "description": "i18next implementation for Lit",
   "scripts": {
     "prepare": "tsc"
@@ -32,10 +32,11 @@
   },
   "homepage": "https://github.com/weavedev/lit-i18next#readme",
   "peerDependencies": {
-    "@lit/reactive-element": "^1.0.0",
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
     "i18next": ">=19.5.0 < 23.0.0"
   },
   "devDependencies": {
-    "typescript": "~4.3.5"
+    "@lit/reactive-element": "^2.0.0",
+    "typescript": "~5.3.3"
   }
 }

--- a/src/localized-decorator.ts
+++ b/src/localized-decorator.ts
@@ -5,8 +5,26 @@
  */
 
 import type { ReactiveElement } from '@lit/reactive-element';
-import type { ClassDescriptor } from '@lit/reactive-element/decorators/base';
+import type { Constructor } from '@lit/reactive-element/decorators/base';
 import { LocalizeOptions, updateWhenLocaleChanges } from './localized-controller';
+
+// From the TC39 Decorators proposal
+interface ClassDescriptor {
+    kind: 'class';
+    elements: ClassElement[];
+    finisher?: <T>(clazz: Constructor<T>) => void | Constructor<T>;
+}
+
+// From the TC39 Decorators proposal
+interface ClassElement {
+    kind: 'field' | 'method';
+    key: PropertyKey;
+    placement: 'static' | 'prototype' | 'own';
+    initializer?: Function;
+    extras?: ClassElement[];
+    finisher?: <T>(clazz: Constructor<T>) => void | Constructor<T>;
+    descriptor?: PropertyDescriptor;
+}
 
 /**
  * Class decorator to enable re-rendering the given LitElement whenever a new


### PR DESCRIPTION
This should add support for Lit 3.x which brings an updated version of `@lit/reactive-element` (2.x).